### PR TITLE
Adapt to requirements for inclusion as default HACS integration

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,15 @@
+# https://developers.home-assistant.io/blog/2020/04/16/hassfest/
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,84 +1,20 @@
----
-name: Validate Integration
-# yamllint disable rule:truthy, rule:syntax
+# https://hacs.xyz/docs/publish/action/
+name: Validate
 
 on:
   push:
-    branches:
-      - main
-      - dev
   pull_request:
-    branches:
-      - main
-      - dev
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   validate-hacs:
-    name: Validate with HACS
     runs-on: ubuntu-latest
     steps:
       - name: HACS validation
         uses: "hacs/action@main"
         with:
           category: "integration"
-
-  validate:
-    name: Validate HASS Integration
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Validate manifest
-        run: |
-          python -c "import json; json.load(open('custom_components/ksenia_lares/manifest.json'))"
-          echo "✓ manifest.json is valid JSON"
-
-      - name: Check required files
-        run: |
-          for file in __init__.py manifest.json; do
-            if [ ! -f "custom_components/ksenia_lares/$file" ]; then
-              echo "✗ Missing required file: $file"
-              exit 1
-            fi
-          done
-          echo "✓ All required files present"
-
-      - name: Validate YAML files
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyyaml
-          python << 'EOF'
-          import sys
-          from pathlib import Path
-          import yaml
-
-          errors = []
-          for yaml_file in Path('custom_components/ksenia_lares').rglob('*.yaml'):
-            try:
-              with open(yaml_file) as f:
-                yaml.safe_load(f)
-            except Exception as e:
-              errors.append(f"{yaml_file}: {e}")
-
-          if errors:
-            print('✗ YAML validation errors:')
-            for err in errors:
-              print(f'  {err}')
-            sys.exit(1)
-          else:
-            print('✓ All YAML files valid (or no YAML files found)')
-          EOF
-
-      - name: Check Python syntax
-        run: |
-          python -m py_compile custom_components/ksenia_lares/*.py
-          echo "✓ Python syntax valid"

--- a/custom_components/ksenia_lares/manifest.json
+++ b/custom_components/ksenia_lares/manifest.json
@@ -1,15 +1,11 @@
 {
   "domain": "ksenia_lares",
-  "name": "Ksenia Lares 4.0",
-  "version": "2.1.0.0",
+  "name": "Ksenia Lares 4.0",  
   "codeowners": ["@emanuelegreco29"],
-  "documentation": "https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/blob/00296b7f902d23ca85ceb0010d45d92ced49f17e/README.md",
-  "issue_tracker": "https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/issues",
   "config_flow": true,
+  "documentation": "https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/blob/main/README.md",
   "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/issues",
   "requirements": ["homeassistant>=2024.1.0"],
-  "branding": {
-    "icon": "https://brands.home-assistant.io/custom_integrations/ksenia_lares/icon.png",
-    "logo": "https://brands.home-assistant.io/custom_integrations/ksenia_lares/logo.png"
-  }
+  "version": "2.1.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Ksenia Lares 4.0",  
-  "country": ["IT", "US"]
+  "name": "Ksenia Lares 4.0",
+  "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
I suggest we add this integration as a default HACS integration.   Solves request in issue #35 :smile: 

This PR is to merge the changes needed to adapt to the HACS rules.

Started on a PR to HACS default repo, I assume you are ok with it, if not let me know and I will remove it :smile: 
https://github.com/hacs/default/pull/5404

HOWTO:
- https://hacs.xyz/docs/publish/start
- https://hacs.xyz/docs/publish/integration/
- Github actions:
  - HACS: https://hacs.xyz/docs/publish/action/#using-a-specific-version
  - HASSFEST: https://developers.home-assistant.io/blog/2020/04/16/hassfest/