### PR TITLE
fix: zone sensors toggling to unknown

### DIFF
--- a/custom_components/ksenia_lares/__init__.py
+++ b/custom_components/ksenia_lares/__init__.py
@@ -187,6 +187,8 @@ async def async_unload_entry(hass, entry):
                 _LOGGER.info("WebSocket manager stopped successfully")
             except Exception as e:
                 _LOGGER.warning("Error stopping WebSocket manager during unload: %s", e)
+            finally:
+                hass.data[DOMAIN].pop("ws_manager", None)
 
         platforms = entry.data.get(CONF_PLATFORMS, DEFAULT_PLATFORMS)
 
@@ -204,9 +206,6 @@ async def async_unload_entry(hass, entry):
         unload_ok = all(
             result is True or isinstance(result, Exception) for result in unload_results
         )
-
-        if unload_ok and ws_manager:
-            hass.data[DOMAIN].pop("ws_manager", None)
 
         _LOGGER.debug(
             "Integration unload complete: unload_ok=%s, platforms=%s", unload_ok, platforms

--- a/custom_components/ksenia_lares/manifest.json
+++ b/custom_components/ksenia_lares/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/issues",
   "requirements": ["homeassistant>=2024.1.0"],
-  "version": "2.2.2.0"
+  "version": "2.2.3.0"
 }

--- a/custom_components/ksenia_lares/sensor.py
+++ b/custom_components/ksenia_lares/sensor.py
@@ -1000,7 +1000,6 @@ class KseniaSensorEntity(SensorEntity):
                             data.get("STA"), data.get("STA", "unknown")
                         )
                         attributes["State"] = mapped_state
-                        data.pop("STA", None)
                         if "BYP" in data:
                             attributes["Bypass"] = (
                                 "Active" if data["BYP"].upper() not in ["NO", "N"] else "Inactive"
@@ -1091,7 +1090,7 @@ class KseniaSensorEntity(SensorEntity):
                                 data.get("STA"), data.get("STA", "unknown")
                             )
                             attributes["State"] = mapped_state
-                            data.pop("STA", None)
+                            self._state = mapped_state
                         if "BYP" in data:
                             attributes["Bypass"] = (
                                 "Active" if data["BYP"].upper() not in ["NO", "N"] else "Inactive"
@@ -1111,7 +1110,6 @@ class KseniaSensorEntity(SensorEntity):
                         if "LBL" in data and data["LBL"]:
                             attributes["Label"] = data["LBL"]
 
-                        self._state = mapped_state
                         self._attributes = attributes
                         # Merge update into raw_data to preserve all fields
                         self._raw_data.update(data)
@@ -1140,6 +1138,7 @@ class KseniaSensorEntity(SensorEntity):
                             state_mapping = {"R": "closed", "A": "open"}
                             mapped_state = state_mapping.get(data["STA"], data["STA"])
                             attributes["State"] = mapped_state
+                            self._state = mapped_state
                         # Bypass
                         if "BYP" in data:
                             attributes["Bypass"] = (
@@ -1166,7 +1165,6 @@ class KseniaSensorEntity(SensorEntity):
                         if "LBL" in data and data["LBL"]:
                             attributes["Label"] = data["LBL"]
 
-                        self._state = mapped_state
                         self._attributes = attributes
                         # Merge update into raw_data to preserve all fields
                         self._raw_data.update(data)


### PR DESCRIPTION
## Summary
Fixes zone sensors toggling to 'unknown' due to a crash

## Root cause
Two bugs and an issue combined caused a crash in realtime updates for
IMOV/EMOV/PMC zone types.
1. Bug - Removing REALTIME data fields
2. Bug - Using undefined variable (the crash)
3. Issue - Duplicate listeners

Reported in: https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/discussions/59#discussioncomment-15861228

## Changes
- Sensor state assignment only if state data exist
- Don't remove STA field from realtime data after use
- websocketmanager add safeguard to prevent duplicates of listeners
- websocketmanager clear all listeners when stopping so callbacks are removed
- Init:  always remove instance of websocketmanager when unloading entity, previously requiring unload to be ok first
- Remove excessive debug logging for calling every listener
- Bump version to 2.2.3.0

## Testing
- [x] Simulator
- [x] Real target system

- No regression found
- Not able to reproduce the reported issue
 