### PR TITLE
chore: replace non-detectable CC BY-NC license with MIT for HACS compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,21 @@
-Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)
+MIT License
 
-=======================================================================
+Copyright (c) 2026 emanuelegreco29
 
-By using this work, you agree to the following terms:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-You are free to:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Share — copy and redistribute the material in any medium or format.
-
-Adapt — remix, transform, and build upon the material.
-
-Under the following terms:
-
-Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
-
-NonCommercial — You may not use the material for commercial purposes.
-
-No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
-
-=======================================================================
-
-Disclaimer:
-
-THE MATERIAL IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE MATERIAL OR THE USE OR OTHER DEALINGS IN THE MATERIAL.
-
-=======================================================================
-
-For the full license text, visit:https://creativecommons.org/licenses/by-nc/4.0/legalcode
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Issue

It seems HACS has tightened the rules for allowed licenses


>[validate-hacs](https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/actions/runs/28763141314/job/85282230742#step:3:10)
 <Validation license> failed:  The repository license could not be identified (SPDX: NOASSERTION) (More info: https://hacs.xyz/docs/publish/include#check-license )

Link to first failed action job: https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/actions/runs/28763141314

## Suggestion
* Change `LICENSE` file to MIT license