### PR TITLE
CI: Bump Node.js to 24 and update checkout and github-script actions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -14,5 +14,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v7"
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,7 +20,7 @@ jobs:
       discussions: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Wait for other workflows to complete
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const EXCLUDE    = ['pre-release.yml'];
@@ -102,7 +102,7 @@ jobs:
 
       - name: Check quality gates
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const workflows = [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use newer versions of key actions, improving security and ensuring compatibility with the latest features.

**Dependency updates in GitHub Actions workflows:**

* Updated all instances of `actions/checkout` from version `v4` to `v7` in `.github/workflows/hassfest.yaml`, `.github/workflows/lint.yml`, `.github/workflows/pre-release.yml`, and `.github/workflows/test.yml`. [[1]](diffhunk://#diff-1ac46986a8988cdd5278f7aaa408779d0cff148ec22a0bb78aefbf5ab4af9beaL17-R17) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L38-R38) [[3]](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607L23-R23) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L32-R32)

* Updated `actions/github-script` from version `v7` to `v9` in `.github/workflows/pre-release.yml` for the "Wait for other workflows to complete" and "Check quality gates" steps. [[1]](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607L64-R64) [[2]](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607L105-R105)- Bump to Node.js 24 runtime
  - bump actions/checkout to v7
  - bump actions/github-script to v9

## BACKGROUND
Warnings in CI actions:

>[Check Quality Gates & Create Pre-Release](https://github.com/emanuelegreco29/Ksenia_Lares_4.0-HASS_Addon/actions/runs/29808588256/job/88564358451#step:13:2)
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/github-script@v7. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


