### PR TITLE
fix: scope hass.data by config entry to support multiple panels

### DIFF
--- a/custom_components/ksenia_lares/__init__.py
+++ b/custom_components/ksenia_lares/__init__.py
@@ -261,10 +261,11 @@ def _register_device(hass, entry, ip, use_ssl, port, system_info):
     )
 
 
-def _cleanup_ws_manager(hass) -> None:
+def _cleanup_ws_manager(hass, entry_id) -> None:
     """Remove the ws_manager from hass.data if present."""
-    if DOMAIN in hass.data and "ws_manager" in hass.data[DOMAIN]:
-        hass.data[DOMAIN].pop("ws_manager", None)
+    entry_data = hass.data.get(DOMAIN, {}).get(entry_id)
+    if entry_data and "ws_manager" in entry_data:
+        entry_data.pop("ws_manager", None)
 
 
 async def _setup_connection(hass, entry, ip, port, pin, use_ssl, brand) -> WebSocketManager:
@@ -292,7 +293,7 @@ async def _setup_connection(hass, entry, ip, port, pin, use_ssl, brand) -> WebSo
         brand=brand,
         periodic_read_interval=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
     )
-    hass.data.setdefault(DOMAIN, {})["ws_manager"] = ws_manager
+    hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})["ws_manager"] = ws_manager
     try:
         connection_method = ws_manager.connectSecure if use_ssl else ws_manager.connect
         _LOGGER.info(f"Starting connection to {ip}:{port}")
@@ -308,10 +309,10 @@ async def _setup_connection(hass, entry, ip, port, pin, use_ssl, brand) -> WebSo
         _LOGGER.info("Initial data available, setup continuing")
         return ws_manager
     except asyncio.CancelledError:
-        _cleanup_ws_manager(hass)
+        _cleanup_ws_manager(hass, entry.entry_id)
         raise
     except Exception as e:
-        _cleanup_ws_manager(hass)
+        _cleanup_ws_manager(hass, entry.entry_id)
         error_msg = f"Failed to connect to Ksenia Lares at {ip}:{port}: {e}"
         _LOGGER.warning("%s - HA will retry with backoff", error_msg)
         raise ConfigEntryNotReady(error_msg) from e
@@ -361,9 +362,10 @@ async def async_setup_entry(hass, entry):
         system_info = await ws_manager.getSystemVersion()
         device_info = build_device_info(ip, port, use_ssl, system_info)
         _register_device(hass, entry, ip, use_ssl, port, system_info)
-        hass.data[DOMAIN]["device_info"] = device_info
+        entry_data = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
+        entry_data["device_info"] = device_info
         mac = system_info.get("MAC")
-        hass.data[DOMAIN]["mac"] = mac
+        entry_data["mac"] = mac
 
         platforms = entry.data.get(CONF_PLATFORMS, DEFAULT_PLATFORMS)
 
@@ -431,7 +433,8 @@ async def async_unload_entry(hass, entry):
                     await asyncio.sleep(0)  # Allow task to process cancellation
 
         # Gracefully handle cases where setup failed and ws_manager wasn't created
-        ws_manager = hass.data.get(DOMAIN, {}).get("ws_manager")
+        entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+        ws_manager = entry_data.get("ws_manager")
         if ws_manager:
             try:
                 await ws_manager.stop()
@@ -439,7 +442,10 @@ async def async_unload_entry(hass, entry):
             except Exception as e:
                 _LOGGER.warning("Error stopping WebSocket manager during unload: %s", e)
             finally:
-                hass.data[DOMAIN].pop("ws_manager", None)
+                entry_data.pop("ws_manager", None)
+
+        # Drop the whole per-entry slot once cleaned up
+        hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
 
         platforms = entry.data.get(CONF_PLATFORMS, DEFAULT_PLATFORMS)
 

--- a/custom_components/ksenia_lares/alarm_control_panel.py
+++ b/custom_components/ksenia_lares/alarm_control_panel.py
@@ -106,9 +106,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     via scenarios. Scenarios are discovered from configuration using CAT field.
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
 
         # Discover scenarios and build CAT-based mapping
         scenarios = await ws_manager.getScenarios()

--- a/custom_components/ksenia_lares/binary_sensor.py
+++ b/custom_components/ksenia_lares/binary_sensor.py
@@ -80,9 +80,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     motion sensors (imov, emov), and sirens.
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
         entities = []
 
         # Add zone-based binary sensors

--- a/custom_components/ksenia_lares/button.py
+++ b/custom_components/ksenia_lares/button.py
@@ -18,9 +18,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     - Clear commands (communications, alarms, faults)
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
         entities = []
 
         # Add scenario execution buttons

--- a/custom_components/ksenia_lares/climate.py
+++ b/custom_components/ksenia_lares/climate.py
@@ -104,9 +104,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     (TEMPERATURES entries with ID_TH != "NA").
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
 
         thermostats = await ws_manager.getThermostats()
         _LOGGER.debug("Found %d thermostat zones", len(thermostats))

--- a/custom_components/ksenia_lares/climate.py
+++ b/custom_components/ksenia_lares/climate.py
@@ -197,7 +197,7 @@ class KseniaClimateEntity(KseniaEntity, ClimateEntity):
             return None
         try:
             return float(raw)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return None
 
     @property
@@ -209,7 +209,7 @@ class KseniaClimateEntity(KseniaEntity, ClimateEntity):
             return None
         try:
             return float(val)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return None
 
     @property

--- a/custom_components/ksenia_lares/cover.py
+++ b/custom_components/ksenia_lares/cover.py
@@ -20,9 +20,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     - Position setting (0-100%)
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
 
         rolls = await ws_manager.getRolls()
         _LOGGER.debug("Found %d roller blinds", len(rolls))

--- a/custom_components/ksenia_lares/cover.py
+++ b/custom_components/ksenia_lares/cover.py
@@ -103,7 +103,7 @@ class KseniaRollEntity(KseniaEntity, CoverEntity):
                     break
                 try:
                     new_pos = int(data["POS"])
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     new_pos = None
                 # If there's a recent pending command, keep the local state
                 if self._pending_command is not None:

--- a/custom_components/ksenia_lares/light.py
+++ b/custom_components/ksenia_lares/light.py
@@ -19,9 +19,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     Supports on/off control.
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
 
         lights = await ws_manager.getLights()
         _LOGGER.debug("Found %d lights", len(lights))

--- a/custom_components/ksenia_lares/sensor.py
+++ b/custom_components/ksenia_lares/sensor.py
@@ -44,9 +44,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     - Event logs
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
         entities = []
 
         initial_counts = await _add_all_device_sensors(ws_manager, device_info, base_id, entities)

--- a/custom_components/ksenia_lares/switch.py
+++ b/custom_components/ksenia_lares/switch.py
@@ -19,9 +19,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     - Zone bypass controls (for zones that support bypass)
     """
     try:
-        ws_manager = hass.data[DOMAIN]["ws_manager"]
-        device_info = hass.data[DOMAIN].get("device_info")
-        base_id = hass.data[DOMAIN].get("mac") or ws_manager.ip
+        ws_manager = hass.data[DOMAIN][config_entry.entry_id]["ws_manager"]
+        device_info = hass.data[DOMAIN][config_entry.entry_id].get("device_info")
+        base_id = hass.data[DOMAIN][config_entry.entry_id].get("mac") or ws_manager.ip
         entities = []
 
         # Add output switches

--- a/custom_components/ksenia_lares/websocketmanager.py
+++ b/custom_components/ksenia_lares/websocketmanager.py
@@ -372,7 +372,7 @@ class WebSocketManager:
         # Debug mode based on logger level (safe for mocks)
         try:
             self._debug_mode = logger.getEffectiveLevel() <= logging.DEBUG
-        except TypeError, AttributeError:
+        except (TypeError, AttributeError):
             # Handle test mocks or non-standard loggers
             self._debug_mode = False
 
@@ -1673,7 +1673,7 @@ class WebSocketManager:
         """
         try:
             return int(value)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return default
 
     async def process_command_queue(self):


### PR DESCRIPTION
hass.data[DOMAIN] was a flat dict shared across all config entries. With two panels configured, each setup overwrote ws_manager/device_info/mac of the previous one, causing entities from both panels to bind to whichever connection loaded last. Scoped storage under hass.data[DOMAIN][entry.entry_id] in __init__.py and all platform files.

Tested on a live installation with two independent Lares 4.0 panels on separate sites connected via VPN.